### PR TITLE
Reduced padding between conversations (#51)

### DIFF
--- a/app/src/main/res/layout/item_conversation.xml
+++ b/app/src/main/res/layout/item_conversation.xml
@@ -13,9 +13,9 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:paddingStart="@dimen/small_margin"
-        android:paddingTop="@dimen/activity_margin"
+        android:paddingTop="@dimen/medium_margin"
         android:paddingEnd="@dimen/normal_margin"
-        android:paddingBottom="@dimen/activity_margin">
+        android:paddingBottom="@dimen/medium_margin">
 
         <ImageView
             android:id="@+id/conversation_image"


### PR DESCRIPTION
#### What is it?
- [X] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
Changed padding values between conversations to use the same values as call history entries in Phone.

#### Before/After Screenshots/Screen Record
- Before:

![Screenshot_1](https://github.com/FossifyOrg/Messages/assets/85929121/20beefdc-c8a8-41c5-b188-f77ad444c0c9)

- After:

![Screenshot_2](https://github.com/FossifyOrg/Messages/assets/85929121/2303edd4-eb43-45d4-9eb8-9bee8bcb2ca1)

#### Fixes the following issue(s)
- Fixes #51

#### Acknowledgement
- [X] I read the [contribution guidelines](https://github.com/FossifyOrg/Messages/blob/master/CONTRIBUTING.md).
