### PR TITLE
Fix missing .json file extension when exporting messages

### DIFF
--- a/app/src/main/kotlin/org/fossify/messages/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/org/fossify/messages/activities/SettingsActivity.kt
@@ -106,7 +106,7 @@ class SettingsActivity : SimpleActivity() {
     private fun setupMessagesExport() {
         binding.settingsExportMessagesHolder.setOnClickListener {
             ExportMessagesDialog(this) { fileName ->
-                saveDocument.launch(fileName)
+                saveDocument.launch("$fileName.json")
             }
         }
     }


### PR DESCRIPTION
Very similar to FossifyOrg/Notes#14 (which has a more detailed commit message). Basically, some file pickers don't automatically append the extension, so we should do it ourselves. It doesn't cause problems.

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Before/After Screenshots/Screen Record
None, but see FossifyOrg/Notes#13 for screenshots of a similar issue in the Notes app.

#### Fixes the following issue(s)
- Fixes part of #88

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Messages/blob/master/CONTRIBUTING.md).
