### PR TITLE
Use a unique app name for debug builds

### DIFF
--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,3 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="app_launcher_name">Messages_debug</string>
 </resources>


### PR DESCRIPTION
This matches the other Fossify apps. It helps avoid confusion when a user installs both an official release and a debug version.

#### What is it?
- [ ] Bugfix
- [x] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
- Change the app name from "Messages" to "Messages_debug" in debug builds.

#### Before/After Screenshots/Screen Record
- Before:
  <img alt="before" src="https://github.com/FossifyOrg/Messages/assets/5887562/d73c70d4-e034-4069-8128-34f5f3395143" width="200">
- After:
  <img alt="after" src="https://github.com/FossifyOrg/Messages/assets/5887562/36f244b3-7d4c-47d4-9f17-0510ca666c45" width="200"> <img alt="after_app_details" src="https://github.com/FossifyOrg/Messages/assets/5887562/0e2b59e7-e139-4423-a26b-8fd98c96d165" width="200">
  (The debug app name gets truncated to "Messag..." in the app listing, but at least it's different from "Messages". The "App info" screen shows the full name.)

#### Fixes the following issue(s)
- Suggested by @QuestioningEspecialy in https://github.com/fossifyorg/messages/issues/6#issuecomment-2105940085

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Messages/blob/master/CONTRIBUTING.md).
