### PR TITLE
Fix missing messages after import on Android 14 due to subscriptionId

### DIFF
--- a/app/src/main/kotlin/org/fossify/messages/helpers/MessagesImporter.kt
+++ b/app/src/main/kotlin/org/fossify/messages/helpers/MessagesImporter.kt
@@ -48,7 +48,14 @@ class MessagesImporter(private val activity: SimpleActivity) {
                 activity.toast(org.fossify.commons.R.string.no_entries_for_importing)
                 return
             }
-            ImportMessagesDialog(activity, deserializedList)
+            val messages = deserializedList.map { message ->
+                // workaround for messages not being imported on Android 14 when the device has a different subscriptionId (see #191)
+                when (message) {
+                    is SmsBackup -> message.copy(subscriptionId = -1)
+                    is MmsBackup -> message.copy(subscriptionId = -1)
+                }
+            }
+            ImportMessagesDialog(activity, messages)
         } catch (e: SerializationException) {
             activity.toast(org.fossify.commons.R.string.invalid_file_format)
         } catch (e: IllegalArgumentException) {


### PR DESCRIPTION
#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR

On Android 14, imported messages are not visible if their subscriptionId[1] does not correspond to one of the SIMs in the device. As a workaround, we set subscriptionId to -1 ("unknown") on all messages during import.

This does mean that when exporting then importing on the same device, the SIM associations will be lost. But that doesn't seem noticeable.

Credit: SMS Import / Export app, https://www.github.com/tmo1/sms-ie/issues/128

[1] https://developer.android.com/identity/user-data-ids#mobile-subscription-status

#### Fixes the following issue(s)
- Fixes #191.

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Messages/blob/master/CONTRIBUTING.md).
