### PR TITLE
Fix conversation dates on import

### DIFF
--- a/app/src/main/kotlin/org/fossify/messages/extensions/Context.kt
+++ b/app/src/main/kotlin/org/fossify/messages/extensions/Context.kt
@@ -1114,7 +1114,11 @@ fun Context.deleteSmsDraft(threadId: Long) {
 }
 
 fun Context.updateLastConversationMessage(threadId: Long) {
-    // update the date and the snippet of the thread, by triggering the
+    updateLastConversationMessage(setOf(threadId))
+}
+
+fun Context.updateLastConversationMessage(threadIds: Iterable<Long>) {
+    // update the date and the snippet of the threads, by triggering the
     // following Android code (which runs even if no messages are deleted):
     // https://android.googlesource.com/platform/packages/providers/TelephonyProvider/+/android14-release/src/com/android/providers/telephony/MmsSmsProvider.java#1409
     val uri = Threads.CONTENT_URI
@@ -1122,8 +1126,10 @@ fun Context.updateLastConversationMessage(threadId: Long) {
         "1 = 0" // always-false condition, because we don't actually want to delete any messages
     try {
         contentResolver.delete(uri, selection, null)
-        val newConversation = getConversations(threadId)[0]
-        insertOrUpdateConversation(newConversation)
+        for (threadId in threadIds) {
+            val newConversation = getConversations(threadId)[0]
+            insertOrUpdateConversation(newConversation)
+        }
     } catch (e: Exception) {
     }
 }

--- a/app/src/main/kotlin/org/fossify/messages/helpers/MessagesImporter.kt
+++ b/app/src/main/kotlin/org/fossify/messages/helpers/MessagesImporter.kt
@@ -96,6 +96,7 @@ class MessagesImporter(private val activity: SimpleActivity) {
                         messagesFailed++
                     }
                 }
+                messageWriter.fixCoversationDates()
                 refreshMessages()
             } catch (e: Exception) {
                 activity.showErrorToast(e)

--- a/app/src/main/kotlin/org/fossify/messages/helpers/MessagesWriter.kt
+++ b/app/src/main/kotlin/org/fossify/messages/helpers/MessagesWriter.kt
@@ -11,6 +11,7 @@ import com.klinker.android.send_message.Utils
 import org.fossify.commons.extensions.getLongValue
 import org.fossify.commons.extensions.queryCursor
 import org.fossify.commons.helpers.isRPlus
+import org.fossify.messages.extensions.updateLastConversationMessage
 import org.fossify.messages.models.MmsAddress
 import org.fossify.messages.models.MmsBackup
 import org.fossify.messages.models.MmsPart
@@ -19,12 +20,14 @@ import org.fossify.messages.models.SmsBackup
 class MessagesWriter(private val context: Context) {
     private val INVALID_ID = -1L
     private val contentResolver = context.contentResolver
+    private val modifiedThreadIds = mutableSetOf<Long>()
 
     fun writeSmsMessage(smsBackup: SmsBackup) {
         val contentValues = smsBackup.toContentValues()
         val threadId = Utils.getOrCreateThreadId(context, smsBackup.address)
         contentValues.put(Sms.THREAD_ID, threadId)
         if (!smsExist(smsBackup)) {
+            modifiedThreadIds.add(threadId)
             contentResolver.insert(Sms.CONTENT_URI, contentValues)
         }
     }
@@ -50,6 +53,7 @@ class MessagesWriter(private val context: Context) {
         if (threadId != INVALID_ID) {
             contentValues.put(Mms.THREAD_ID, threadId)
             if (!mmsExist(mmsBackup)) {
+                modifiedThreadIds.add(threadId)
                 contentResolver.insert(Mms.CONTENT_URI, contentValues)
             }
             val messageId = getMmsId(mmsBackup)
@@ -151,5 +155,17 @@ class MessagesWriter(private val context: Context) {
             exists = it.count > 0
         }
         return exists
+    }
+
+    /** Fixes the timestamps of all conversations modified by previous writes. */
+    fun fixCoversationDates() {
+        // This method should be called after messages are written, to set the correct conversation
+        // timestamps.
+        //
+        // It is necessary because when we insert a message, Android's Telephony provider sets the
+        // conversation date to the current time rather than the time of the message that was
+        // inserted. Source code reference:
+        // https://android.googlesource.com/platform/packages/providers/TelephonyProvider/+/android14-release/src/com/android/providers/telephony/MmsSmsDatabaseHelper.java#134
+        context.updateLastConversationMessage(modifiedThreadIds)
     }
 }


### PR DESCRIPTION
#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
- Fix conversation dates on import (see commit message for details)
- Add bulk version of updateLastConversationMessage() for use by the above fix

#### Fixes the following issue(s)
- Fixes #146
- Fixes #42

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Messages/blob/master/CONTRIBUTING.md).

Tested in emulator on Android 8 and 14 using the steps from #146.