### PR TITLE
Access db on background thread

### DIFF
--- a/app/src/main/kotlin/org/fossify/messages/receivers/MmsReceiver.kt
+++ b/app/src/main/kotlin/org/fossify/messages/receivers/MmsReceiver.kt
@@ -85,8 +85,10 @@ class MmsReceiver : MmsReceivedReceiver() {
                 threadId = mms.threadId,
                 bitmap = glideBitmap
             )
-            val conversation = context.getConversations(mms.threadId).firstOrNull() ?: return@post
+
             ensureBackgroundThread {
+                val conversation = context.getConversations(mms.threadId).firstOrNull()
+                    ?: return@ensureBackgroundThread
                 context.insertOrUpdateConversation(conversation)
                 context.updateUnreadCountBadge(context.conversationsDB.getUnreadConversations())
                 refreshMessages()


### PR DESCRIPTION
#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
- Moved `Context.getConversations()` call in `ensureBackgroundThread` lambda

(The code was being called on the main thread since e3f7d809872d27d419cb2f08dcf4803ba62ba81b. This came into light only because the `getConversations()` method now also accesses a Room DB and Room as usual throws error about operations on the main thread).

#### Fixes the following issue(s)
- Fixes #287 

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Messages/blob/master/CONTRIBUTING.md).
