### PR TITLE
Copy links in a message to clipboard when long pressing on bubble message

### DIFF
--- a/app/src/main/kotlin/org/fossify/messages/adapters/ThreadAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/messages/adapters/ThreadAdapter.kt
@@ -29,7 +29,6 @@ import com.bumptech.glide.request.RequestListener
 import com.bumptech.glide.request.RequestOptions
 import com.bumptech.glide.request.target.Target
 import org.fossify.commons.adapters.MyRecyclerViewListAdapter
-import org.fossify.commons.compose.extensions.linkColor
 import org.fossify.commons.dialogs.ConfirmationDialog
 import org.fossify.commons.extensions.*
 import org.fossify.commons.helpers.SimpleContactsHelper
@@ -50,9 +49,6 @@ import org.fossify.messages.models.Attachment
 import org.fossify.messages.models.Message
 import org.fossify.messages.models.ThreadItem
 import org.fossify.messages.models.ThreadItem.*
-import kotlin.text.map
-import kotlin.text.matches
-import kotlin.text.toList
 
 class ThreadAdapter(
     activity: SimpleActivity,
@@ -275,11 +271,16 @@ class ThreadAdapter(
         }
     }
 
-    private fun findLinks(text : String): List<String> {
-        val regex = Regex("(https?:\\/\\/(?:www\\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\\.[^\\s]{2,}|www\\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\\.[^\\s]{2,}|https?:\\/\\/(?:www\\.|(?!www))[a-zA-Z0-9]+\\.[^\\s]{2,}|www\\.[a-zA-Z0-9]+\\.[^\\s]{2,})")
+    private fun findLinks(text: String): List<String> {
+        val regex =
+            Regex(
+                "(https?:\\/\\/(?:www\\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\\.[^\\s]{2,}|www\\.[a-zA-Z0-9][a-zA-Z0-9-]" +
+                    "+[a-zA-Z0-9]\\.[^\\s]{2,}|https?:\\/\\/(?:www\\.|(?!www))[a-zA-Z0-9]+\\.[^\\s]{2,}|www\\.[a-zA-Z0-9]+\\.[^\\s]{2,})"
+            )
         val links = regex.findAll(text)
         return links.map { it.value }.toList()
     }
+
     private fun setupView(holder: ViewHolder, view: View, message: Message) {
         ItemMessageBinding.bind(view).apply {
             threadMessageHolder.isSelected = selectedKeys.contains(message.hashCode())
@@ -289,7 +290,7 @@ class ThreadAdapter(
                 beVisibleIf(message.body.isNotEmpty())
                 setOnLongClickListener {
                     holder.viewLongClicked()
-                    findLinks(text.toString()).map{ link -> activity.copyToClipboard(link)}
+                    findLinks(text.toString()).map { link -> activity.copyToClipboard(link) }
                     true
                 }
 

--- a/app/src/main/kotlin/org/fossify/messages/adapters/ThreadAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/messages/adapters/ThreadAdapter.kt
@@ -29,6 +29,7 @@ import com.bumptech.glide.request.RequestListener
 import com.bumptech.glide.request.RequestOptions
 import com.bumptech.glide.request.target.Target
 import org.fossify.commons.adapters.MyRecyclerViewListAdapter
+import org.fossify.commons.compose.extensions.linkColor
 import org.fossify.commons.dialogs.ConfirmationDialog
 import org.fossify.commons.extensions.*
 import org.fossify.commons.helpers.SimpleContactsHelper
@@ -49,6 +50,9 @@ import org.fossify.messages.models.Attachment
 import org.fossify.messages.models.Message
 import org.fossify.messages.models.ThreadItem
 import org.fossify.messages.models.ThreadItem.*
+import kotlin.text.map
+import kotlin.text.matches
+import kotlin.text.toList
 
 class ThreadAdapter(
     activity: SimpleActivity,
@@ -254,7 +258,6 @@ class ThreadAdapter(
             if (attachment != null) {
                 putExtra(Intent.EXTRA_STREAM, attachment.getUri())
             }
-
             activity.startActivity(this)
         }
     }
@@ -272,6 +275,11 @@ class ThreadAdapter(
         }
     }
 
+    private fun findLinks(text : String): List<String> {
+        val regex = Regex("(https?:\\/\\/(?:www\\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\\.[^\\s]{2,}|www\\.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\\.[^\\s]{2,}|https?:\\/\\/(?:www\\.|(?!www))[a-zA-Z0-9]+\\.[^\\s]{2,}|www\\.[a-zA-Z0-9]+\\.[^\\s]{2,})")
+        val links = regex.findAll(text)
+        return links.map { it.value }.toList()
+    }
     private fun setupView(holder: ViewHolder, view: View, message: Message) {
         ItemMessageBinding.bind(view).apply {
             threadMessageHolder.isSelected = selectedKeys.contains(message.hashCode())
@@ -281,6 +289,7 @@ class ThreadAdapter(
                 beVisibleIf(message.body.isNotEmpty())
                 setOnLongClickListener {
                     holder.viewLongClicked()
+                    findLinks(text.toString()).map{ link -> activity.copyToClipboard(link)}
                     true
                 }
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
[ ] Bugfix
[x] Feature
[ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
Added function that extract URLs in a text
Copy all URLs from a message to clipboard

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
Fixes #107

I added a function findLinks() to parse the message text and return a list of all URLs in that text, then every URLs are copied to clipboard by long pressing the message bubble.
#### Acknowledgement
[x] I read the [contribution guidelines](https://github.com/FossifyOrg/Messages/blob/master/CONTRIBUTING.md).