### PR TITLE
Allow importing binary files on Android 9

### DIFF
--- a/app/src/main/kotlin/org/fossify/messages/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/org/fossify/messages/activities/SettingsActivity.kt
@@ -31,7 +31,7 @@ import org.fossify.commons.helpers.NavigationIcon
 import org.fossify.commons.helpers.PROTECTION_FINGERPRINT
 import org.fossify.commons.helpers.SHOW_ALL_TABS
 import org.fossify.commons.helpers.ensureBackgroundThread
-import org.fossify.commons.helpers.isPiePlus
+import org.fossify.commons.helpers.isQPlus
 import org.fossify.commons.helpers.isTiramisuPlus
 import org.fossify.commons.models.RadioItem
 import org.fossify.messages.R
@@ -63,7 +63,7 @@ class SettingsActivity : SimpleActivity() {
         add("application/json")
         add("application/xml")
         add("text/xml")
-        if (!isPiePlus()) {
+        if (!isQPlus()) {
             add("application/octet-stream")
         }
     }


### PR DESCRIPTION
The previous check was off by one version. The workaround needs to be applied on Android versions up to *and including* Android 9 (Pie), so it should be applied unless we are on Android >= 10 (Q).

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
- Fix version check

#### Related
- The code was introduced in #137 

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Messages/blob/master/CONTRIBUTING.md).
