### PR TITLE
Limit received MMS message length to 5000

### DIFF
--- a/app/src/main/kotlin/org/fossify/messages/extensions/Context.kt
+++ b/app/src/main/kotlin/org/fossify/messages/extensions/Context.kt
@@ -54,6 +54,7 @@ import org.fossify.messages.databases.MessagesDatabase
 import org.fossify.messages.helpers.AttachmentUtils.parseAttachmentNames
 import org.fossify.messages.helpers.Config
 import org.fossify.messages.helpers.FILE_SIZE_NONE
+import org.fossify.messages.helpers.MAX_MESSAGE_LENGTH
 import org.fossify.messages.helpers.MESSAGES_LIMIT
 import org.fossify.messages.helpers.NotificationHelper
 import org.fossify.messages.helpers.generateRandomId
@@ -476,7 +477,10 @@ fun Context.getMmsAttachment(id: Long, getImageResolutions: Boolean): MessageAtt
         val partId = cursor.getLongValue(Mms._ID)
         val mimetype = cursor.getStringValue(Mms.Part.CONTENT_TYPE)
         if (mimetype == "text/plain") {
-            messageAttachment.text = cursor.getStringValue(Mms.Part.TEXT) ?: ""
+            messageAttachment.text = cursor
+                .getStringValue(Mms.Part.TEXT)
+                ?.take(MAX_MESSAGE_LENGTH)
+                .orEmpty()
         } else if (mimetype.startsWith("image/") || mimetype.startsWith("video/")) {
             val fileUri = Uri.withAppendedPath(uri, partId.toString())
             var width = 0

--- a/app/src/main/kotlin/org/fossify/messages/helpers/Constants.kt
+++ b/app/src/main/kotlin/org/fossify/messages/helpers/Constants.kt
@@ -79,6 +79,7 @@ const val FILE_SIZE_1_MB = 1_048_576L
 const val FILE_SIZE_2_MB = 2_097_152L
 
 const val MESSAGES_LIMIT = 30
+const val MAX_MESSAGE_LENGTH = 5000
 
 // intent launch request codes
 const val PICK_PHOTO_INTENT = 42


### PR DESCRIPTION
#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR

This limit is to avoid ANRs just in case there are very large text messages in the system (either added on purpose or sent by someone else to trigger ANRs in the user's device). Other messaging apps have set it to 2000 but I'm not sure since I can't test MMS messages :(

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Messages/blob/master/CONTRIBUTING.md).
