### PR TITLE
Use 0dp (match constraints) as width for text view

### DIFF
--- a/app/src/main/res/layout/layout_invalid_short_code_info.xml
+++ b/app/src/main/res/layout/layout_invalid_short_code_info.xml
@@ -3,17 +3,12 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal"
     android:paddingHorizontal="@dimen/normal_margin">
 
     <androidx.appcompat.widget.AppCompatTextView
         android:id="@+id/reply_disabled_text"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_alignParentStart="true"
-        android:layout_gravity="center_vertical|end"
-        android:clickable="true"
-        android:focusable="true"
         android:padding="@dimen/activity_margin"
         android:text="@string/invalid_short_code"
         app:layout_constraintBottom_toBottomOf="parent"


### PR DESCRIPTION
#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR

Previously, the text was using `wrap_content`, which could cause cropping in certain language configurations.

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #325

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Messages/blob/master/CONTRIBUTING.md).
