### PR TITLE
feat: reorder action buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Reordered action buttons throughout the app
+
 ### Added
 - Ability to save multiple attachments ([#75])
 

--- a/app/src/main/res/menu/cab_archived_conversations.xml
+++ b/app/src/main/res/menu/cab_archived_conversations.xml
@@ -4,17 +4,17 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:ignore="AppCompatResource,AlwaysShowAction">
     <item
-        android:id="@+id/cab_delete"
-        android:icon="@drawable/ic_delete_vector"
-        android:showAsAction="always"
-        android:title="@string/delete"
-        app:showAsAction="always" />
-    <item
         android:id="@+id/cab_unarchive"
         android:icon="@drawable/ic_unarchive_vector"
         android:showAsAction="ifRoom"
         android:title="@string/unarchive"
         app:showAsAction="ifRoom" />
+    <item
+        android:id="@+id/cab_delete"
+        android:icon="@drawable/ic_delete_vector"
+        android:showAsAction="always"
+        android:title="@string/delete"
+        app:showAsAction="always" />
     <item
         android:id="@+id/cab_select_all"
         android:icon="@drawable/ic_select_all_vector"

--- a/app/src/main/res/menu/cab_conversations.xml
+++ b/app/src/main/res/menu/cab_conversations.xml
@@ -4,49 +4,29 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:ignore="AppCompatResource,AlwaysShowAction">
     <item
-        android:id="@+id/cab_delete"
-        android:icon="@drawable/ic_delete_vector"
-        android:showAsAction="always"
-        android:title="@string/delete"
-        app:showAsAction="always" />
-    <item
-        android:id="@+id/cab_add_number_to_contact"
-        android:icon="@drawable/ic_add_person_vector"
-        android:showAsAction="always"
-        android:title="@string/add_number_to_contact"
-        app:showAsAction="always" />
-    <item
         android:id="@+id/cab_dial_number"
         android:icon="@drawable/ic_phone_vector"
         android:showAsAction="always"
         android:title="@string/dial_number"
         app:showAsAction="always" />
     <item
-        android:id="@+id/cab_block_number"
-        android:icon="@drawable/ic_minus_circle_vector"
-        android:title="@string/block_number"
-        app:showAsAction="ifRoom" />
-    <item
         android:id="@+id/cab_archive"
         android:icon="@drawable/ic_archive_vector"
-        android:showAsAction="ifRoom"
+        android:showAsAction="always"
         android:title="@string/archive"
+        app:showAsAction="always" />
+    <item
+        android:id="@+id/cab_delete"
+        android:icon="@drawable/ic_delete_vector"
+        android:showAsAction="always"
+        android:title="@string/delete"
+        app:showAsAction="always" />
+    <item
+        android:id="@+id/cab_select_all"
+        android:icon="@drawable/ic_select_all_vector"
+        android:showAsAction="ifRoom"
+        android:title="@string/select_all"
         app:showAsAction="ifRoom" />
-    <item
-        android:id="@+id/cab_copy_number"
-        android:showAsAction="never"
-        android:title="@string/copy_number_to_clipboard"
-        app:showAsAction="never" />
-    <item
-        android:id="@+id/cab_rename_conversation"
-        android:icon="@drawable/ic_edit_vector"
-        android:title="@string/rename_conversation"
-        app:showAsAction="ifRoom" />
-    <item
-        android:id="@+id/cab_conversation_details"
-        android:showAsAction="never"
-        android:title="@string/conversation_details"
-        app:showAsAction="never" />
     <item
         android:id="@+id/cab_mark_as_read"
         android:showAsAction="never"
@@ -58,18 +38,40 @@
         android:title="@string/mark_as_unread"
         app:showAsAction="never" />
     <item
+        android:id="@+id/cab_add_number_to_contact"
+        android:showAsAction="never"
+        android:title="@string/add_number_to_contact"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/cab_copy_number"
+        android:showAsAction="never"
+        android:title="@string/copy_number_to_clipboard"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/cab_rename_conversation"
+        android:showAsAction="never"
+        android:title="@string/rename_conversation"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/cab_conversation_details"
+        android:showAsAction="never"
+        android:title="@string/conversation_details"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/cab_block_number"
+        android:showAsAction="never"
+        android:title="@string/block_number"
+        app:showAsAction="never" />
+    <item
         android:id="@+id/cab_pin_conversation"
         android:icon="@drawable/ic_pin_filled_vector"
+        android:showAsAction="never"
         android:title="@string/pin_conversation"
-        app:showAsAction="ifRoom" />
+        app:showAsAction="never" />
     <item
         android:id="@+id/cab_unpin_conversation"
         android:icon="@drawable/ic_pin_filled_vector"
+        android:showAsAction="never"
         android:title="@string/unpin_conversation"
-        app:showAsAction="ifRoom" />
-    <item
-        android:id="@+id/cab_select_all"
-        android:icon="@drawable/ic_select_all_vector"
-        android:title="@string/select_all"
-        app:showAsAction="ifRoom" />
+        app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/menu/cab_thread.xml
+++ b/app/src/main/res/menu/cab_thread.xml
@@ -6,36 +6,27 @@
     <item
         android:id="@+id/cab_copy_to_clipboard"
         android:icon="@drawable/ic_copy_vector"
-        android:showAsAction="ifRoom"
+        android:showAsAction="always"
         android:title="@string/copy_to_clipboard"
-        app:showAsAction="ifRoom" />
+        app:showAsAction="always" />
     <item
         android:id="@+id/cab_share"
         android:icon="@drawable/ic_share_vector"
-        android:showAsAction="ifRoom"
+        android:showAsAction="always"
         android:title="@string/share"
-        app:showAsAction="ifRoom" />
+        app:showAsAction="always" />
     <item
         android:id="@+id/cab_save_as"
         android:icon="@drawable/ic_save_vector"
+        android:showAsAction="ifRoom"
         android:title="@string/save_as"
-        app:showAsAction="ifRoom" />
-    <item
-        android:id="@+id/cab_properties"
-        android:icon="@drawable/ic_info_vector"
-        android:title="@string/properties"
         app:showAsAction="ifRoom" />
     <item
         android:id="@+id/cab_delete"
         android:icon="@drawable/ic_delete_vector"
-        android:showAsAction="never"
+        android:showAsAction="always"
         android:title="@string/delete"
-        app:showAsAction="never" />
-    <item
-        android:id="@+id/cab_restore"
-        android:showAsAction="never"
-        android:title="@string/restore"
-        app:showAsAction="never" />
+        app:showAsAction="always" />
     <item
         android:id="@+id/cab_forward_message"
         android:showAsAction="never"
@@ -49,6 +40,18 @@
     <item
         android:id="@+id/cab_select_all"
         android:icon="@drawable/ic_select_all_vector"
+        android:showAsAction="never"
         android:title="@string/select_all"
-        app:showAsAction="ifRoom" />
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/cab_properties"
+        android:icon="@drawable/ic_info_vector"
+        android:showAsAction="never"
+        android:title="@string/properties"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/cab_restore"
+        android:showAsAction="never"
+        android:title="@string/restore"
+        app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/menu/cab_thread.xml
+++ b/app/src/main/res/menu/cab_thread.xml
@@ -6,21 +6,15 @@
     <item
         android:id="@+id/cab_copy_to_clipboard"
         android:icon="@drawable/ic_copy_vector"
-        android:showAsAction="always"
+        android:showAsAction="ifRoom"
         android:title="@string/copy_to_clipboard"
-        app:showAsAction="always" />
+        app:showAsAction="ifRoom" />
     <item
         android:id="@+id/cab_share"
         android:icon="@drawable/ic_share_vector"
-        android:showAsAction="always"
+        android:showAsAction="ifRoom"
         android:title="@string/share"
-        app:showAsAction="always" />
-    <item
-        android:id="@+id/cab_delete"
-        android:icon="@drawable/ic_delete_vector"
-        android:showAsAction="always"
-        android:title="@string/delete"
-        app:showAsAction="always" />
+        app:showAsAction="ifRoom" />
     <item
         android:id="@+id/cab_save_as"
         android:icon="@drawable/ic_save_vector"
@@ -31,6 +25,12 @@
         android:icon="@drawable/ic_info_vector"
         android:title="@string/properties"
         app:showAsAction="ifRoom" />
+    <item
+        android:id="@+id/cab_delete"
+        android:icon="@drawable/ic_delete_vector"
+        android:showAsAction="never"
+        android:title="@string/delete"
+        app:showAsAction="never" />
     <item
         android:id="@+id/cab_restore"
         android:showAsAction="never"

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -16,11 +16,13 @@
     <item
         android:id="@+id/settings"
         android:icon="@drawable/ic_settings_cog_vector"
+        android:showAsAction="never"
         android:title="@string/settings"
         app:showAsAction="never" />
     <item
         android:id="@+id/about"
         android:icon="@drawable/ic_info_vector"
+        android:showAsAction="never"
         android:title="@string/about"
         app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/menu/menu_thread.xml
+++ b/app/src/main/res/menu/menu_thread.xml
@@ -4,25 +4,20 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:ignore="AppCompatResource">
     <item
-        android:id="@+id/delete"
-        android:icon="@drawable/ic_delete_vector"
-        android:title="@string/delete"
-        app:showAsAction="always" />
-    <item
         android:id="@+id/dial_number"
         android:icon="@drawable/ic_phone_vector"
         android:title="@string/dial_number"
-        app:showAsAction="always" />
+        app:showAsAction="ifRoom" />
     <item
         android:id="@+id/manage_people"
         android:icon="@drawable/ic_add_person_vector"
         android:title="@string/add_person"
-        app:showAsAction="always" />
+        app:showAsAction="ifRoom" />
     <item
         android:id="@+id/rename_conversation"
         android:icon="@drawable/ic_edit_vector"
         android:title="@string/rename_conversation"
-        app:showAsAction="always" />
+        app:showAsAction="ifRoom" />
     <item
         android:id="@+id/archive"
         android:icon="@drawable/ic_archive_vector"
@@ -33,6 +28,11 @@
         android:icon="@drawable/ic_unarchive_vector"
         android:title="@string/unarchive"
         app:showAsAction="ifRoom" />
+    <item
+        android:id="@+id/delete"
+        android:icon="@drawable/ic_delete_vector"
+        android:title="@string/delete"
+        app:showAsAction="never" />
     <item
         android:id="@+id/conversation_details"
         android:showAsAction="never"

--- a/app/src/main/res/menu/menu_thread.xml
+++ b/app/src/main/res/menu/menu_thread.xml
@@ -2,36 +2,39 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    tools:ignore="AppCompatResource">
+    tools:ignore="AppCompatResource,AlwaysShowAction">
     <item
         android:id="@+id/dial_number"
         android:icon="@drawable/ic_phone_vector"
+        android:showAsAction="always"
         android:title="@string/dial_number"
-        app:showAsAction="ifRoom" />
-    <item
-        android:id="@+id/manage_people"
-        android:icon="@drawable/ic_add_person_vector"
-        android:title="@string/add_person"
-        app:showAsAction="ifRoom" />
-    <item
-        android:id="@+id/rename_conversation"
-        android:icon="@drawable/ic_edit_vector"
-        android:title="@string/rename_conversation"
-        app:showAsAction="ifRoom" />
+        app:showAsAction="always" />
     <item
         android:id="@+id/archive"
         android:icon="@drawable/ic_archive_vector"
+        android:showAsAction="always"
         android:title="@string/archive"
-        app:showAsAction="ifRoom" />
+        app:showAsAction="always" />
     <item
         android:id="@+id/unarchive"
         android:icon="@drawable/ic_unarchive_vector"
+        android:showAsAction="always"
         android:title="@string/unarchive"
+        app:showAsAction="always" />
+    <item
+        android:id="@+id/manage_people"
+        android:icon="@drawable/ic_add_person_vector"
+        android:showAsAction="ifRoom"
+        android:title="@string/add_person"
         app:showAsAction="ifRoom" />
     <item
-        android:id="@+id/delete"
-        android:icon="@drawable/ic_delete_vector"
-        android:title="@string/delete"
+        android:id="@+id/add_number_to_contact"
+        android:title="@string/add_number_to_contact"
+        app:showAsAction="never" />
+    <item
+        android:id="@+id/rename_conversation"
+        android:showAsAction="never"
+        android:title="@string/rename_conversation"
         app:showAsAction="never" />
     <item
         android:id="@+id/conversation_details"
@@ -39,22 +42,24 @@
         android:title="@string/conversation_details"
         app:showAsAction="never" />
     <item
-        android:id="@+id/add_number_to_contact"
-        android:title="@string/add_number_to_contact"
-        app:showAsAction="ifRoom" />
+        android:id="@+id/mark_as_unread"
+        android:showAsAction="never"
+        android:title="@string/mark_as_unread"
+        app:showAsAction="never" />
     <item
         android:id="@+id/block_number"
         android:showAsAction="never"
         android:title="@string/block_number"
         app:showAsAction="never" />
     <item
+        android:id="@+id/delete"
+        android:icon="@drawable/ic_delete_vector"
+        android:showAsAction="never"
+        android:title="@string/delete"
+        app:showAsAction="never" />
+    <item
         android:id="@+id/restore"
         android:showAsAction="never"
         android:title="@string/restore_all_messages"
-        app:showAsAction="never" />
-    <item
-        android:id="@+id/mark_as_unread"
-        android:showAsAction="never"
-        android:title="@string/mark_as_unread"
         app:showAsAction="never" />
 </menu>


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [ ] Bug fix
- [x] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
 - Moved the in-chat delete button back into the overflow menu. This makes it slightly harder to accidentally delete conversations by adding another step.
 - Reordered the action buttons throughout the app for better UX (less flickering based on selection) 

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
