### PR TITLE
feat: show number picker when creating new chats or adding members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Ability to save multiple attachments ([#75])
+- Ability to select non-favorite numbers when starting a new conversation ([#153])
+
 ### Changed
 - Reordered action buttons throughout the app
 
-### Added
-- Ability to save multiple attachments ([#75])
+### Fixed
+- Fixed contact number selection when adding members to a group ([#456])
 
 ## [1.3.0] - 2025-09-09
 ### Added
@@ -135,6 +139,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#75]: https://github.com/FossifyOrg/Messages/issues/75
 [#115]: https://github.com/FossifyOrg/Messages/issues/115
 [#135]: https://github.com/FossifyOrg/Messages/issues/135
+[#153]: https://github.com/FossifyOrg/Messages/issues/153
 [#180]: https://github.com/FossifyOrg/Messages/issues/180
 [#209]: https://github.com/FossifyOrg/Messages/issues/209
 [#217]: https://github.com/FossifyOrg/Messages/issues/217
@@ -150,6 +155,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#334]: https://github.com/FossifyOrg/Messages/issues/334
 [#349]: https://github.com/FossifyOrg/Messages/issues/349
 [#359]: https://github.com/FossifyOrg/Messages/issues/359
+[#456]: https://github.com/FossifyOrg/Messages/issues/456
 [#461]: https://github.com/FossifyOrg/Messages/issues/461
 
 [Unreleased]: https://github.com/FossifyOrg/Messages/compare/1.3.0...HEAD

--- a/app/src/main/kotlin/org/fossify/messages/activities/NewConversationActivity.kt
+++ b/app/src/main/kotlin/org/fossify/messages/activities/NewConversationActivity.kt
@@ -7,7 +7,6 @@ import android.view.WindowManager
 import android.widget.Toast
 import com.google.gson.Gson
 import com.reddit.indicatorfastscroll.FastScrollItemIndicator
-import org.fossify.commons.dialogs.RadioGroupDialog
 import org.fossify.commons.extensions.applyColorFilter
 import org.fossify.commons.extensions.areSystemAnimationsEnabled
 import org.fossify.commons.extensions.beGone
@@ -16,11 +15,11 @@ import org.fossify.commons.extensions.beVisibleIf
 import org.fossify.commons.extensions.getColorStateList
 import org.fossify.commons.extensions.getContrastColor
 import org.fossify.commons.extensions.getMyContactsCursor
-import org.fossify.commons.extensions.getPhoneNumberTypeText
 import org.fossify.commons.extensions.getProperPrimaryColor
 import org.fossify.commons.extensions.getProperTextColor
 import org.fossify.commons.extensions.hasPermission
 import org.fossify.commons.extensions.hideKeyboard
+import org.fossify.commons.extensions.maybeShowNumberPickerDialog
 import org.fossify.commons.extensions.normalizeString
 import org.fossify.commons.extensions.onTextChangeListener
 import org.fossify.commons.extensions.toast
@@ -33,7 +32,6 @@ import org.fossify.commons.helpers.NavigationIcon
 import org.fossify.commons.helpers.PERMISSION_READ_CONTACTS
 import org.fossify.commons.helpers.SimpleContactsHelper
 import org.fossify.commons.helpers.ensureBackgroundThread
-import org.fossify.commons.models.RadioItem
 import org.fossify.commons.models.SimpleContact
 import org.fossify.messages.R
 import org.fossify.messages.adapters.ContactsAdapter
@@ -200,30 +198,8 @@ class NewConversationActivity : SimpleActivity() {
             ContactsAdapter(this, contacts, binding.contactsList) {
                 hideKeyboard()
                 val contact = it as SimpleContact
-                val phoneNumbers = contact.phoneNumbers
-                if (phoneNumbers.size > 1) {
-                    val primaryNumber = contact.phoneNumbers.find { it.isPrimary }
-                    if (primaryNumber != null) {
-                        launchThreadActivity(primaryNumber.value, contact.name)
-                    } else {
-                        val items = ArrayList<RadioItem>()
-                        phoneNumbers.forEachIndexed { index, phoneNumber ->
-                            val type = getPhoneNumberTypeText(phoneNumber.type, phoneNumber.label)
-                            items.add(
-                                RadioItem(
-                                    index,
-                                    "${phoneNumber.normalizedNumber} ($type)",
-                                    phoneNumber.normalizedNumber
-                                )
-                            )
-                        }
-
-                        RadioGroupDialog(this, items) {
-                            launchThreadActivity(it as String, contact.name)
-                        }
-                    }
-                } else {
-                    launchThreadActivity(phoneNumbers.first().normalizedNumber, contact.name)
+                maybeShowNumberPickerDialog(contact.phoneNumbers) { number ->
+                    launchThreadActivity(number.normalizedNumber, contact.name)
                 }
             }.apply {
                 binding.contactsList.adapter = this

--- a/app/src/main/kotlin/org/fossify/messages/activities/ThreadActivity.kt
+++ b/app/src/main/kotlin/org/fossify/messages/activities/ThreadActivity.kt
@@ -79,6 +79,7 @@ import org.fossify.commons.extensions.isDynamicTheme
 import org.fossify.commons.extensions.isOrWasThankYouInstalled
 import org.fossify.commons.extensions.isVisible
 import org.fossify.commons.extensions.launchActivityIntent
+import org.fossify.commons.extensions.maybeShowNumberPickerDialog
 import org.fossify.commons.extensions.normalizeString
 import org.fossify.commons.extensions.notificationManager
 import org.fossify.commons.extensions.onTextChangeListener
@@ -623,7 +624,12 @@ class ThreadActivity : SimpleActivity() {
                     val currContacts =
                         (binding.addContactOrNumber.adapter as AutoCompleteTextViewAdapter).resultList
                     val selectedContact = currContacts[position]
-                    addSelectedContact(selectedContact)
+                    maybeShowNumberPickerDialog(selectedContact.phoneNumbers) { phoneNumber ->
+                        val contactWithSelectedNumber = selectedContact.copy(
+                            phoneNumbers = arrayListOf(phoneNumber)
+                        )
+                        addSelectedContact(contactWithSelectedNumber)
+                    }
                 }
 
                 binding.addContactOrNumber.onTextChangeListener {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ eventbus = "3.3.1"
 #Room
 room = "2.8.0"
 #Fossify
-commons = "5.0.2"
+commons = "5.2.0"
 android-smsmms = "c3e678befd"
 indicator-fast-scroll = "4524cd0b61"
 #Gradle


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix
- [x] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Added a number picker when adding members to a group instead of adding all the numbers (#456).
- Removed the starred number condition for the number picker in `NewConversationsActivity`. This ensures the number picker is always shown instead of silently defaulting to the primary number (messaging flow is different from calls).
- Reused `maybeShowNumberPickerDialog()` helper extension from [commons](https://github.com/FossifyOrg/commons/pull/208) to avoid duplication.
 
#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Creating new conversations using single and multiple number contacts
 - Creating a group or adding members to a group

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes #153 
- Closes #456

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [ ] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [ ] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
