### PR TITLE
fix: properly handle keyword blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reordered menu options throughout the app
 
 ### Fixed
+- Fixed keyword blocking for MMS messages ([#99])
 - Fixed contact number selection when adding members to a group ([#456])
 - Fixed a glitch in pattern lock after incorrect attempts
 
@@ -138,6 +139,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#13]: https://github.com/FossifyOrg/Messages/issues/13
 [#70]: https://github.com/FossifyOrg/Messages/issues/70
 [#75]: https://github.com/FossifyOrg/Messages/issues/75
+[#99]: https://github.com/FossifyOrg/Messages/issues/99
 [#115]: https://github.com/FossifyOrg/Messages/issues/115
 [#135]: https://github.com/FossifyOrg/Messages/issues/135
 [#153]: https://github.com/FossifyOrg/Messages/issues/153

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -141,7 +141,7 @@ dependencies {
     implementation(libs.fossify.commons)
     implementation(libs.eventbus)
     implementation(libs.indicator.fast.scroll)
-    implementation(libs.android.smsmms)
+    implementation(libs.mmslib)
     implementation(libs.androidx.swiperefreshlayout)
     implementation(libs.androidx.constraintlayout)
     implementation(libs.androidx.lifecycle.process)

--- a/app/src/main/kotlin/org/fossify/messages/receivers/MmsReceiver.kt
+++ b/app/src/main/kotlin/org/fossify/messages/receivers/MmsReceiver.kt
@@ -24,12 +24,15 @@ import org.fossify.messages.helpers.ReceiverUtils.isMessageFilteredOut
 import org.fossify.messages.helpers.refreshMessages
 import org.fossify.messages.models.Message
 
-// more info at https://github.com/klinker41/android-smsmms
 class MmsReceiver : MmsReceivedReceiver() {
 
     override fun isAddressBlocked(context: Context, address: String): Boolean {
         val normalizedAddress = address.normalizePhoneNumber()
         return context.isNumberBlocked(normalizedAddress)
+    }
+
+    override fun isContentBlocked(context: Context, content: String): Boolean {
+        return isMessageFilteredOut(context, content)
     }
 
     override fun onMessageReceived(context: Context, messageUri: Uri) {
@@ -62,10 +65,6 @@ class MmsReceiver : MmsReceivedReceiver() {
         size: Int,
         address: String
     ) {
-        if (isMessageFilteredOut(context, mms.body)) {
-            return
-        }
-
         val glideBitmap = try {
             Glide.with(context)
                 .asBitmap()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ eventbus = "3.3.1"
 room = "2.8.1"
 #Fossify
 commons = "5.2.0"
-mmslib = "naveensingh~fix-keyword-blocking-SNAPSHOT"
+mmslib = "1.0.0"
 indicator-fast-scroll = "4524cd0b61"
 #Gradle
 gradlePlugins-agp = "8.11.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ eventbus = "3.3.1"
 room = "2.8.1"
 #Fossify
 commons = "5.2.0"
-android-smsmms = "c3e678befd"
+mmslib = "naveensingh~fix-keyword-blocking-SNAPSHOT"
 indicator-fast-scroll = "4524cd0b61"
 #Gradle
 gradlePlugins-agp = "8.11.1"
@@ -43,7 +43,7 @@ compose-detekt = { module = "io.nlopez.compose.rules:detekt", version.ref = "det
 #Fossify
 fossify-commons = { module = "org.fossify:commons", version.ref = "commons" }
 indicator-fast-scroll = { module = "org.fossify:IndicatorFastScroll", version.ref = "indicator-fast-scroll" }
-android-smsmms = { module = "org.fossify:android-smsmms", version.ref = "android-smsmms" }
+mmslib = { module = "org.fossify:mmslib", version.ref = "mmslib" }
 #EventBus
 eventbus = { module = "org.greenrobot:eventbus", version.ref = "eventbus" }
 #Helpers


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
Implemented the new `isContentBlocked()` method from https://github.com/FossifyOrg/mmslib/pull/2. This ensures that the received messages are checked for blocked keywords _before_ they are saved to the system database. 

**Note:** This could have been fixed easily by filtering out existing messages with blocked keywords at run time, but this way is more consistent with how messages from blocked numbers are dropped. 

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - [x] Receiving MMS messages with text (notification + in-app refresh)
 - [x] Receiving MMS messages without text (notification + in-app refresh)
 - [x] Receiving MMS messages with blocked keywords
 - [x] Receiving MMS messages with previously blocked keywords unblocked
 - [x] Sending MMS messages including blocked keywords
 - [x] Sending MMS messages with or without text

I couldn't test it, but [Aga-C](https://github.com/Aga-C) and [laubster](https://github.com/laubster) have confirmed that this works. 

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Messages/issues/99

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [ ] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
